### PR TITLE
Guard against users not using file-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,11 @@ function rewireGraphQLTag(config, env) {
     const gqlExtension = /\.(graphql|gql)$/
 
     const fileLoader = config.module.rules.find(rule=> rule.loader && rule.loader.indexOf("file-loader")!==-1);
-    fileLoader.exclude.push(gqlExtension);
-
+    
+    if (fileLoader !== undefined) {
+        fileLoader.exclude.push(gqlExtension);
+    }
+   
     const gqlTagRule = {
         test: gqlExtension,
         loader: 'graphql-tag/loader',


### PR DESCRIPTION
If the consumer isn't using `file-loader`, don't apply the exclusion.